### PR TITLE
Исправления несогласованности pep 8

### DIFF
--- a/python/function.ipynb
+++ b/python/function.ipynb
@@ -93,7 +93,7 @@
     "    var = 'Python'\n",
     "    if len(var) >= 6:\n",
     "        print(var)\n",
-    "return           # В этом случае функция вернет значение None"
+    "    return           # В этом случае функция вернет значение None"
    ]
   },
   {
@@ -155,7 +155,7 @@
     "def search_len(arg_1):\n",
     "    return len(arg_1) \n",
     "# Лямбда-функция \n",
-    "result = lambda x: len(x)"
+    "result = filter(lambda x: x % 2, [1, 2, 3, 4, 5])"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "    c = []\n",
     "    for i in range(len(s)):\n",
     "        if i%2 == 0:\n",
-    "            c.append(s[I])\n",
+    "            c.append(s[i])\n",
     "    return c"
    ]
   },
@@ -402,11 +402,15 @@
     "        находит элементы с четным индексом (включая 0)\n",
     "        заносит их в созданный список и возвращает его\n",
     "    '''\n",
-    "    assert type(s) == list\n",
+    "    # isinstance вернет True, если проверяемый объект object является экземпляром указанного\n",
+    "    # класса (классов) или его подкласса (прямого, косвенного или виртуального).\n",
+    "    # Если в Вашей программе не нарушался принцип подстановки Барбары-Лисков,\n",
+    "    # то лучше использовать его, вместо прямой проверки типов\n",
+    "    assert isinstance(s, list)\n",
     "    c = []\n",
     "    for i in range(len(s)):\n",
     "        if i%2 == 0:\n",
-    "            c.append(s[I])\n",
+    "            c.append(s[i])\n",
     "    return c"
    ]
   },
@@ -429,11 +433,11 @@
      "evalue": "",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-14-2fd1d2ae175f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msolve\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m''\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m<ipython-input-13-65375417b8ca>\u001b[0m in \u001b[0;36msolve\u001b[0;34m(s)\u001b[0m\n\u001b[1;32m      5\u001b[0m         \u001b[0mзаносит\u001b[0m \u001b[0mих\u001b[0m \u001b[0mв\u001b[0m \u001b[0mсозданный\u001b[0m \u001b[0mсписок\u001b[0m \u001b[0mи\u001b[0m \u001b[0mвозвращает\u001b[0m \u001b[0mего\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     '''\n\u001b[0;32m----> 7\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m     \u001b[0mc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mAssertionError\u001B[0m                            Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-14-2fd1d2ae175f>\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0msolve\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m''\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[0;32m<ipython-input-13-65375417b8ca>\u001B[0m in \u001B[0;36msolve\u001B[0;34m(s)\u001B[0m\n\u001B[1;32m      5\u001B[0m         \u001B[0mзаносит\u001B[0m \u001B[0mих\u001B[0m \u001B[0mв\u001B[0m \u001B[0mсозданный\u001B[0m \u001B[0mсписок\u001B[0m \u001B[0mи\u001B[0m \u001B[0mвозвращает\u001B[0m \u001B[0mего\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      6\u001B[0m     '''\n\u001B[0;32m----> 7\u001B[0;31m     \u001B[0;32massert\u001B[0m \u001B[0mtype\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0ms\u001B[0m\u001B[0;34m)\u001B[0m \u001B[0;34m==\u001B[0m \u001B[0mlist\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      8\u001B[0m     \u001B[0mc\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0;34m[\u001B[0m\u001B[0;34m]\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      9\u001B[0m     \u001B[0;32mfor\u001B[0m \u001B[0mi\u001B[0m \u001B[0;32min\u001B[0m \u001B[0mrange\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mlen\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0ms\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mAssertionError\u001B[0m: "
      ]
     }
    ],

--- a/python/type_and_objects.ipynb
+++ b/python/type_and_objects.ipynb
@@ -62,11 +62,11 @@
    "source": [
     "null_variable = None \n",
     "not_null_variable = 'something' \n",
-    "if null_variable == None: \n",
+    "if null_variable is None:\n",
     "    print('null_variable is None') \n",
     "else: \n",
     "    print('null_variable is not None') \n",
-    "if not_null_variable == None: \n",
+    "if not_null_variable is None:\n",
     "    print('not_null_variable is None') \n",
     "else: \n",
     "    print('not_null_variable is not None')"
@@ -182,7 +182,7 @@
     "\n",
     " \n",
     "## Генератор\n",
-    "Генератор списков используется, когда нам нужно вывести последовательность целых чисел. Более\n",
+    "Генератор используется, когда нам нужно создать, но не сохранять последовательность элементов. Более\n",
     "\n",
     "подробно об этом типе будет рассказано в уроке \"Циклы\".\n",
     "\n",


### PR DESCRIPTION
Присваивать lambda какой-то переменной не рекомендуется так как осложняется отладка подобных программ. Лямбды в питоне предназначены для встраивания в более крупное выражение

В случае, если программист не нарушал принцип подстановки Барбары-Лисков, при проверке через isinstance будет больше функциональность, так как будут все необходимые поля и работа методов не будет нарушена даже у дочерних классов, а прямая проверка типов не пропустит дочерний от list, к примеру, хотя необходимые для работы методы и поля присутствуют и их поведение соответствует ожиданиям

Сравнение с None выглядит гораздо более читаемо через is или is not